### PR TITLE
polyfill for neo-python responses missing 0x in the tx vins

### DIFF
--- a/neo-interface/src/components/UnconfirmedTxInfo.js
+++ b/neo-interface/src/components/UnconfirmedTxInfo.js
@@ -23,7 +23,7 @@ class UnconfirmedTxInfo extends Component {
         if (unconfirmTxInfo.fulfilled) {
             let vins = unconfirmTxInfo.value.data.result.vin
             let vin_txs = vins.map((v, i, arr) => {
-                return v.txid.substring(2);
+                return v.txid.length == 66 ? v.txid.substring(2) : v.txid;
             })
             console.log(vin_txs);
             let y = JSON.stringify(unconfirmTxInfo.value, null, 4, 50)


### PR DESCRIPTION
Currently there is a bug in neo-python-rpc https://github.com/CityOfZion/neo-python/issues/575 that means the 0x prefix in tx's is being dropped. This is resolved for now with this commit. We can reverse this commit once fixed (although it will work either way).