### PR TITLE
Add latest test update

### DIFF
--- a/unhappy_nodes.md
+++ b/unhappy_nodes.md
@@ -43,6 +43,140 @@ Suggestion: Do not use
 </pre>
 
 <pre>
+List of Nodes with Corrupted Blocks Based on Bad Blocks found in http://108.252.121.18:10332
+Owner(s): Known and Unknown
+Version: All are using NEO-PYTHON
+Reported by: @jseagrave21
+Issue Link (if appicable): N/A
+Type: Python
+Issue: Some nodes have corrupted blocks
+Details: The corrupted blocks are shown below their parent nodes. Bad blocks were queried based on bad blocks found in http://108.252.121.18:10332
+Test: Based on a test conducted on 29 Aug 2018
+{
+    "http://node2.nyc3.bridgeprotocol.io:10332": [
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "http://node2.sgp1.bridgeprotocol.io:10332": [
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "https://pyrpc1.redpulse.com:10331": [
+        2669088,
+        2669006,
+        2668576,
+        2654445,
+        2649000,
+        2648846,
+        2647581,
+        2642303,
+        2642297,
+        2639344,
+        2639318,
+        2636778,
+        2636746,
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "https://pyrpc2.redpulse.com:10331": [
+        2669088,
+        2669006,
+        2668576,
+        2654445,
+        2649000,
+        2648846,
+        2647581,
+        2642303,
+        2642297,
+        2639344,
+        2639318,
+        2636778,
+        2636746,
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "http://pyrpc1.redpulse.com:10332": [
+        2669088,
+        2669006,
+        2668576,
+        2654445,
+        2649000,
+        2648846,
+        2647581,
+        2642303,
+        2642297,
+        2639344,
+        2639318,
+        2636778,
+        2636746,
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "http://pyrpc2.redpulse.com:10332": [
+        2669088,
+        2669006,
+        2668576,
+        2654445,
+        2649000,
+        2648846,
+        2647581,
+        2642303,
+        2642297,
+        2639344,
+        2639318,
+        2636778,
+        2636746,
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "https://pyrpc1.narrative.org:443": [],
+    "https://pyrpc2.narrative.org:443": [],
+    "https://pyrpc3.narrative.org:443": [],
+    "https://pyrpc4.narrative.org:443": [],
+    "http://108.252.121.18:10332": [
+        2669088,
+        2669006,
+        2668576,
+        2654445,
+        2649000,
+        2648846,
+        2647581,
+        2642303,
+        2642297,
+        2639344,
+        2639318,
+        2636778,
+        2636746,
+        2631533,
+        2631520,
+        2628876,
+        2628874,
+        2603556
+    ],
+    "http://101.100.174.24:10332": [],
+    "http://52.204.61.212:10332": []
+}
+Suggestion: Do not use nodes with bad blocks
+
+<pre>
 Node: https://seed1.spotcoin.com:10332
 Owner: Spotcoin Team
 Version: NEO:2.7.6


### PR DESCRIPTION
All nodes queried are NEO-Python nodes.
Bad blocks were found by querying node http://108.252.121.18:10332"
Based on a test conducted using this script:

```
import requests
import sys
import json

url = ["http://node2.nyc3.bridgeprotocol.io:10332", "http://node2.sgp1.bridgeprotocol.io:10332", "https://pyrpc1.redpulse.com:10331", \
"https://pyrpc2.redpulse.com:10331", "http://pyrpc1.redpulse.com:10332", "http://pyrpc2.redpulse.com:10332", "https://pyrpc1.narrative.org:443", \
"https://pyrpc2.narrative.org:443", "https://pyrpc3.narrative.org:443", "https://pyrpc4.narrative.org:443", "http://108.252.121.18:10332", \
"http://101.100.174.24:10332", "http://52.204.61.212:10332"]

def get_block(block):
    body = {"jsonrpc": "2.0","method": "getblock","params": [block, 1],"id": 2}
    req = requests.post(url[q], json=body)
    req = req.json()
    return req

def update_progress(job_title, progress):
    length = 20 # modify this to change the length
    block = int(round(length*progress))
    msg = "\r{0}: [{1}] {2}%".format(job_title, "#"*block + "-"*(length-block), round(progress*100, 2))
    if progress >= 1: msg += " DONE\r\n"
    sys.stdout.write(msg)
    sys.stdout.flush()

bad_blocks = [2669088,2669006,2668576,2654445,2649000,2648846,2647581,2642303, \
2642297, 2639344, 2639318, 2636778, 2636746, 2631533, 2631520, 2628876, 2628874, \
2603556]


bad_nodes = {}

url_length = len(url) - 1
q = 0
while q <= url_length:

    # process
    db = []
    p = 0
    while p <= len(bad_blocks) - 1:
        # progress bar
        update_progress("Process Nodes", q / url_length)
        update_progress("Process Blocks", p / len(bad_blocks))

        # process
        temp = get_block(bad_blocks[p])
        if 'error' in temp.keys():
            db.append(bad_blocks[p])

        p += 1

    bad_nodes.update({url[q]: db})

    q += 1

print("{}".format(json.dumps(bad_nodes, indent=4)))
```